### PR TITLE
Closes #25.

### DIFF
--- a/R/get_current_weather.R
+++ b/R/get_current_weather.R
@@ -73,13 +73,23 @@ get_current_weather <-
 
         the_station_name <- likely_stations[1]
         if (length(likely_stations) > 1) {
-          warning(
-            "Multiple stations match station_name. Using\n\tstation_name = '",
-            the_station_name,
-            "'\ndid you mean:\n\tstation_name = '",
-            likely_stations[-1],
-            "'?"
-          )
+          # Likely common use case
+          # (otherwise defaults to KURNELL RADAR which does not provide observations)
+          if (toupper(station_name) == "SYDNEY" && 'SYDNEY (OBSERVATORY HILL)' %in% likely_stations) {
+            likely_stations <- c('SYDNEY (OBSERVATORY HILL)',
+                                 setdiff(likely_stations,
+                                         'SYDNEY (OBSERVATORY HILL)'))
+            the_station_name <- 'SYDNEY (OBSERVATORY HILL)'
+          }
+
+          warning("Multiple stations match station_name. ",
+                  "Using\n\tstation_name = '",
+                  the_station_name,
+                  "'\n\nDid you mean any of the following?\n",
+                  paste0("\tstation_name = '",
+                         likely_stations[-1],
+                         "'",
+                         collapse = "\n"))
         }
       }
 

--- a/tests/testthat/test-get_current_weather.R
+++ b/tests/testthat/test-get_current_weather.R
@@ -23,6 +23,12 @@ test_that("Query of 'Melbourne Airport' returns time if cooked.", {
   expect_true("POSIXt" %in% class(YMML$aifstime_utc))
 })
 
+test_that("Query of 'Sydney' defaults to Observatory Hill", {
+  expect_warning(get_current_weather("Sydney"), regexp = "Multiple stations match")
+  SYD <- suppressWarnings(get_current_weather("Sydney"))
+  expect_equal(unique(SYD$name), "Sydney - Observatory Hill")
+})
+
 test_that("latlon: Query of c(-27, 149) returns Surat (QLD, between Roma and St George).", {
   expect_message(get_current_weather(latlon = c(-27, 149)), regexp = "SURAT")
   Surat <- get_current_weather(latlon = c(-27, 149), emit_latlon_msg = FALSE)


### PR DESCRIPTION
In addition, adds explicit rule for `get_current_weather('Sydney')`.

I think this is better than space separation because it is clearer in the console. I am anticipating users will scan the list and then copy the argument to be pasted into the next call. Having it on one line would require a bit of extra effort on the part of users which we can help them avoid. 

```r
Warning message:
In get_current_weather("Newcastle") :
  Multiple stations match station_name. Using
	station_name = 'NEWCASTLE NOBBYS SIGNAL STATION AWS'

Did you mean any of the following?
	station_name = 'WILLIAMTOWN (NEWCASTLE  RADAR)'
	station_name = 'NEWCASTLE UNIVERSITY'
```

One slight problem is if there are a huge number of possible sites:

```r
get_current_weather("MOUNT")
```

My RStudio session truncates the list. I think this is acceptable: at worst there will be < 1000 lines printed, and it will probably only happen once per user! 